### PR TITLE
#165500647 Convert delete account API to use database

### DIFF
--- a/server/controller/accountController.js
+++ b/server/controller/accountController.js
@@ -61,5 +61,23 @@ class AccountController {
       return response(res, 500, 'Server error');
     }
   }
+
+  /**
+  * @static
+  * @description Allow Admin/Staff to delete an account
+  * @param {object} req - Request object
+  * @param {object} res - Response object
+  * @returns {object} Json
+  * @memberof AccountController
+  */
+  static async deleteAccount(req, res) {
+    try {
+      const { params: { accountNumber } } = req;
+      await pool.query('delete from accounts where accountnumber = $1;', [accountNumber]);
+      return response(res, 200, 'Account successfully deleted');
+    } catch (error) {
+      return response(res, 500, 'Server error');
+    }
+  }
 }
 export default AccountController;

--- a/server/route/api/account.js
+++ b/server/route/api/account.js
@@ -22,11 +22,11 @@ accountRoutes.patch('/:accountNumber',
   AccountValidation.checkIfAccountExist,
   AccountController.updateAccountStatus);
 
-// accountRoutes.delete('/:accountNumber',
-//   AuthMiddleware.checkIfUserIsAuthenticated,
-//   AccountValidation.staffChecker,
-//   AccountValidation.checkIfAccountExist,
-//   AccountController.deleteAccount);
+accountRoutes.delete('/:accountNumber',
+  AuthMiddleware.checkIfUserIsAuthenticated,
+  AccountValidation.staffChecker,
+  AccountValidation.checkIfAccountExist,
+  AccountController.deleteAccount);
 
 
 export default accountRoutes;

--- a/server/spec/accounts.test.js
+++ b/server/spec/accounts.test.js
@@ -141,71 +141,70 @@ describe('PATCH /api/v1/accounts', () => {
   });
 });
 
-// describe('DELETE /api/v1/accounts', () => {
-//   const staff = {
-//     email: 'emekaike@gmail.com',
-//     password: '123456789',
-//   };
-//   const admin = {
-//     email: 'ezikeonyinyefavour@gmail.com',
-//     password: '123456789',
-//   };
+describe('DELETE /api/v1/accounts', () => {
+  const staff = {
+    email: 'emekaike@gmail.com',
+    password: '123456789',
+  };
+  const admin = {
+    email: 'ezikeonyinyefavour@gmail.com',
+    password: '123456789',
+  };
 
-//   let adminToken;
-//   before((done) => {
-//     chai.request(app)
-//       .post('/api/v1/auth/signin')
-//       .send(admin)
-//       .end((err, res) => {
-//         adminToken = res.body.data.token;
-//         done();
-//       });
-//   });
+  let adminToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send(admin)
+      .end((err, res) => {
+        adminToken = res.body.data.token;
+        done();
+      });
+  });
 
-//   let staffToken;
-//   before((done) => {
-//     chai.request(app)
-//       .post('/api/v1/auth/signin')
-//       .send(staff)
-//       .end((err, res) => {
-//         staffToken = res.body.data.token;
-//         done();
-//       });
-//   });
-
-
-//   it('should successfully delete an account', (done) => {
-//     chai.request(app)
-//       .delete('/api/v1/accounts/9701234568')
-//       .set('authorization', adminToken)
-//       // .send(delete)
-//       .end((err, res) => {
-//         expect(res.body.status).to.equal(200);
-//         expect(res.body.message).to.equal('Account successfully deleted');
-//         done();
-//       });
-//   });
-
-//   it('should allow staff to successfully delete an account', (done) => {
-//     chai.request(app)
-//       .delete('/api/v1/accounts/9601234578')
-//       .set('authorization', staffToken)
-//       .end((err, res) => {
-//         expect(res.body.status).to.equal(200);
-//         expect(res.body.message).to.equal('Account successfully deleted');
-//         done();
-//       });
-//   });
+  let staffToken;
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send(staff)
+      .end((err, res) => {
+        staffToken = res.body.data.token;
+        done();
+      });
+  });
 
 
-//   it('should not update status if Account is not found', (done) => {
-//     chai.request(app)
-//       .delete('/api/v1/accounts/97012345686686')
-//       .set('authorization', adminToken)
-//       .end((err, res) => {
-//         expect(res.body.status).to.equal(404);
-//         expect(res.body.message).to.equal('Account not found');
-//         done();
-//       });
-//   });
-// });
+  it('should successfully delete an account', (done) => {
+    chai.request(app)
+      .delete('/api/v1/accounts/1102345679')
+      .set('authorization', adminToken)
+      .end((err, res) => {
+        expect(res.body.status).to.equal(200);
+        expect(res.body.message).to.equal('Account successfully deleted');
+        done();
+      });
+  });
+
+  it('should allow staff to successfully delete an account', (done) => {
+    chai.request(app)
+      .delete('/api/v1/accounts/1102345679')
+      .set('authorization', staffToken)
+      .end((err, res) => {
+        expect(res.body.status).to.equal(200);
+        expect(res.body.message).to.equal('Account successfully deleted');
+        done();
+      });
+  });
+
+
+  it('should not update status if Account is not found', (done) => {
+    chai.request(app)
+      .delete('/api/v1/accounts/97012345686686')
+      .set('authorization', adminToken)
+      .end((err, res) => {
+        expect(res.body.status).to.equal(404);
+        expect(res.body.message).to.equal('Account Not Found');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Configure delete account API to use database

#### Description of Task to be completed?
Convert delete account API to read from database

#### How should this be manually tested?
- Clone the repo
- Run npm install to download all packages
- Use npm run test to test the endpoint, you can postman can also be used to test.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#165500647](https://www.pivotaltracker.com/story/show/165500647)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
